### PR TITLE
 Adding viewControllers as childsViewControllers

### DIFF
--- a/Sources/ScrollingStackContainer/ScrollingStackController.swift
+++ b/Sources/ScrollingStackContainer/ScrollingStackController.swift
@@ -141,6 +141,9 @@ public class ScrollingStackController: UIViewController, UIScrollViewDelegate {
 			self.removeAllViewControllers()
 			self.items = newValue.map { StackItem($0 as! UIViewController, $0.preferredAppearanceInStack() ) }
 			self.relayoutItems()
+            self.items.forEach {
+                self.addChild($0.controller)
+            }
 		}
 		get { return self.items.map { $0.controller as! StackContainable } }
 	}


### PR DESCRIPTION
Fixing issue #7 

Only the view of the stack viewControllers is being added to the ScrollingStackController view, there is no refrence kept for the childViewController itself 

So for example if we have our ScrollingStackContainer inside a UINavigationController, and it contains a tableView as one of it SubViewControllers, we can't access the navigationController to push a new viewController , this PR wil allow us to do the following 

```
   // tableView delegate method
    func tableView(_ tableView: UITableView, didSelectRowAt indexPath: IndexPath) {
        let vc = NewViewController(nibName: "NewViewController", bundle: nil)
        self.parent?.navigationController?.pushViewController(vc, animated: true)
    }
```

Assuming that **self** here references the viewController that control our tableView